### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Bouncy
- https://darktend.github.io/Bouncy/
+
+https://darktend.github.io/Bouncy/
+
+## Deploy
+
+The project is configured to deploy automatically to **GitHub Pages** using GitHub Actions.
+
+### How it works
+
+- Workflow file: `.github/workflows/deploy.yml`
+- Trigger: every push to the `main` branch (and manual `workflow_dispatch`)
+- It publishes the repository root as a static site artifact.
+
+### One-time GitHub setup
+
+1. Push this repository to GitHub.
+2. Open **Settings → Pages**.
+3. In **Build and deployment**, choose **Source: GitHub Actions**.
+4. Ensure your default production branch is `main` (or adjust the workflow branch trigger if you use another branch).
+
+After that, each push to `main` will deploy the latest version automatically.


### PR DESCRIPTION
### Motivation
- Provide an automated, reliable way to publish the static site to GitHub Pages from the repository using GitHub Actions.
- Document the deployment flow and one-time GitHub setup so maintainers can enable publishing quickly.

### Description
- Add a new workflow file at `.github/workflows/deploy.yml` that publishes the repository root as a Pages artifact and deploys it using `actions/deploy-pages`, with triggers for pushes to `main` and manual `workflow_dispatch`.
- Configure workflow-level `permissions` for Pages, `concurrency` to avoid overlapping runs, and use `actions/checkout@v4`, `actions/configure-pages@v5`, and `actions/upload-pages-artifact@v3` in the job steps.
- Update `README.md` with a `Deploy` section that explains the workflow file, triggers, and the one-time steps to enable GitHub Pages in the repository settings.

### Testing
- Ran `git diff --check` to verify there are no whitespace or diff warnings and it completed successfully.
- Ran `node --check gulpfile.js` to validate the project `gulpfile.js` parses under Node and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ae1c4dcfc8329b9c916075026b167)